### PR TITLE
 pin/device burnout bugs

### DIFF
--- a/src/PS2KeyAdvanced.cpp
+++ b/src/PS2KeyAdvanced.cpp
@@ -399,7 +399,9 @@ _bitcount++;               // Now point to next bit
 switch( _bitcount )
   {
   case 1: // Start bit due to Arduino bug
-          digitalWrite( PS2_DataPin, ( LOW ) );
+          digitalWrite( PS2_DataPin, LOW );
+          pinMode( PS2_DataPin, OUTPUT );
+          
           break;
   case 2:
   case 3:
@@ -411,6 +413,11 @@ switch( _bitcount )
   case 9:
           // Data bits
           val = _shiftdata & 0x01;   // get LSB
+    if (val)
+        pininput( PS2_DataPin );
+    else 
+        pinMode( PS2_DataPin, OUTPUT );
+    
           digitalWrite( PS2_DataPin, val ); // send start bit //BUG SHOULD NOT WRITE HIGH ON OUT
           _parity += val;            // another one received ?
           _shiftdata >>= 1;          // right _SHIFT one place for next bit
@@ -470,10 +477,12 @@ if( !( _tx_ready & _HANDSHAKE ) && ( _tx_ready & _COMMAND ) )
   }
 
 // set pins to outputs and high //AND THEY GOT BURNED OUT, BECOUSE YOU ARE NOT ALLOWED TO SET THEM OUTPUT HIGH, ONLY PULLUP BY 5kom RESISTOR
-digitalWrite( PS2_DataPin, HIGH );
-pinMode( PS2_DataPin, OUTPUT );
-digitalWrite( PS2_IrqPin, HIGH );
-pinMode( PS2_IrqPin, OUTPUT );
+//digitalWrite( PS2_DataPin, HIGH );
+//pinMode( PS2_DataPin, INPUT_PULLUP );
+  pininput( PS2_DataPin );
+//digitalWrite( PS2_IrqPin, HIGH );
+//pinMode( PS2_IrqPin, INPUT_PULLUP );
+  pininput( PS2_IrqPin );
 delayMicroseconds( 10 );
 #if defined(ARDUINO_ARCH_SAM)
 // STOP interrupt handler as Due etc. a lot faster than Uno/Mega
@@ -482,10 +491,12 @@ detachInterrupt( digitalPinToInterrupt( PS2_IrqPin ) );
 #endif
 // set Clock LOW
 digitalWrite( PS2_IrqPin, LOW );
+  pinMode( PS2_IrqPin, OUTPUT );
 // set clock low for 60us
 delayMicroseconds( 60 );
 // Set data low - Start bit
 digitalWrite( PS2_DataPin, LOW );
+  pinMode( PS2_DataPin, OUTPUT );
 // set clock to input_pullup
 pininput( PS2_IrqPin );
 #if defined(ARDUINO_ARCH_SAM)

--- a/src/PS2KeyAdvanced.cpp
+++ b/src/PS2KeyAdvanced.cpp
@@ -411,7 +411,7 @@ switch( _bitcount )
   case 9:
           // Data bits
           val = _shiftdata & 0x01;   // get LSB
-          digitalWrite( PS2_DataPin, val ); // send start bit
+          digitalWrite( PS2_DataPin, val ); // send start bit //BUG SHOULD NOT WRITE HIGH ON OUT
           _parity += val;            // another one received ?
           _shiftdata >>= 1;          // right _SHIFT one place for next bit
           break;
@@ -469,7 +469,7 @@ if( !( _tx_ready & _HANDSHAKE ) && ( _tx_ready & _COMMAND ) )
   _ps2mode |= _WAIT_RESPONSE;
   }
 
-// set pins to outputs and high
+// set pins to outputs and high //AND THEY GOT BURNED OUT, BECOUSE YOU ARE NOT ALLOWED TO SET THEM OUTPUT HIGH, ONLY PULLUP BY 5kom RESISTOR
 digitalWrite( PS2_DataPin, HIGH );
 pinMode( PS2_DataPin, OUTPUT );
 digitalWrite( PS2_IrqPin, HIGH );

--- a/src/PS2KeyAdvanced.cpp
+++ b/src/PS2KeyAdvanced.cpp
@@ -415,9 +415,11 @@ switch( _bitcount )
           val = _shiftdata & 0x01;   // get LSB
     if (val)
         pininput( PS2_DataPin );
-    else 
+    else
+    {
+        digitalWrite( PS2_IrqPin, LOW );
         pinMode( PS2_DataPin, OUTPUT );
-    
+    }
           digitalWrite( PS2_DataPin, val ); // send start bit //BUG SHOULD NOT WRITE HIGH ON OUT
           _parity += val;            // another one received ?
           _shiftdata >>= 1;          // right _SHIFT one place for next bit


### PR DESCRIPTION
you can't set output high on open collector interface, as if there some static error on bus, and you would got device output low (which is allowed) and you outputting high, so you will burn out controller pin or device.
from ps/2 description:
The Data and Clock lines are both open-collector with pullup resistors to Vcc.  An "open-collector" interface has two possible state: low, or high impedance.  In the "low" state, a transistor pulls the line to ground level.  In the "high impedance" state, the interface acts as an open circuit and doesn't drive the line low or high. Furthermore, a "pullup" resistor is connected between the bus and Vcc so the bus is pulled high if none of the devices on the bus are actively pulling it low.